### PR TITLE
Changes so naisible can run outside NAV 

### DIFF
--- a/example-inventory-file
+++ b/example-inventory-file
@@ -25,3 +25,11 @@ pod_network_cidr=192.168.0.0/16
 domain=devillo.no
 cluster_domain=nais.local
 cluster_lb_suffix=nais.domain.com
+
+# If you need a proxy to access internet, configure the following variables.
+nais_http_proxy=http://webproxy-utvikler.nav.no:8088
+nais_https_proxy=http://webproxy-utvikler.nav.no:8088
+nais_no_proxy="localhost,127.0.0.1,.local,.adeo.no,.nav.no,.aetat.no,.devillo.no,.oera.no,{{ansible_default_ipv4.address}}"
+
+# Remote username. Defaults to deployer if not set
+nais_remote_user=deployer

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,5 +1,7 @@
 ---
 proxy_env:
-      http_proxy: http://webproxy-utvikler.nav.no:8088
-      https_proxy: http://webproxy-utvikler.nav.no:8088
-      no_proxy: localhost,127.0.0.1,.local,.adeo.no,.nav.no,.aetat.no,.devillo.no,.oera.no,{{ansible_default_ipv4.address}}
+    http_proxy: "{{ nais_http_proxy | default(None) }}"
+    https_proxy: "{{ nais_https_proxy | default(None) }}"
+    no_proxy: "{{ nais_no_proxy | default(None) }}"
+
+remote_user: "{{ nais_remote_user | default('deployer') }}"

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,10 @@ Variables
 |domain|devillo.no|Domain name of your k8s nodes, required to issue certificates|
 |cluster_domain|nais.local|Domain name inside your cluster|
 |cluster_lb_suffix|nais.devillo.no|Domain your external services will be exposed|
-
+|nais_http_proxy|http://webproxy.domain.com:8088|Address to proxy for http traffic|
+|nais_https_proxy|http://webproxy.domain.com:8088|Address to proxy for https traffic|
+|nais_no_proxy|"localhost,127.0.0.1,.local,.devillo.no,{{ansible_default_ipv4.address}}"|This variable should contain a comma-separated list of domain extensions proxy should _not_ be used for.|
+|nais_remote_user|deployer|User for remote access to the hosts configured under [masters] and [workers] section. Defaults to deployer|
 
 Example inventory file
 ---

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,7 +4,7 @@
     - /etc/pki/ca-trust/source/anchors
     - /etc/kubernetes/kubeconfigs
     - /etc/kubernetes/pki
-    - /etc/systemd/system/docker.service.d 
+    - /etc/systemd/system/docker.service.d
 
 - name: Install proxy cert
   copy: src=files/webproxy.crt dest=/etc/pki/ca-trust/source/anchors/webproxy.crt
@@ -55,11 +55,26 @@
 
 - name: Docker proxy settings
   template: src=templates/docker-proxy.conf.j2 dest=/etc/systemd/system/docker.service.d/proxy.conf
+  when: proxy_env.http_proxy|default("") != ""
+
+# Check if sensu-core exist
+- name: Check if sensu core is installed
+  command: rpm -q sensu
+  ignore_errors: yes
+  register: sensu_rpm_check
+
+# Check if puppet-agent exist
+- name: Check if puppet-agent is installed
+  command: rpm -q puppet-agent
+  ignore_errors: yes
+  register: puppet_agent_rpm_check
 
 - name: Disable puppet agent
   shell: /bin/puppet agent --disable
   ignore_errors: yes
+  when: puppet_agent_rpm_check.rc == 0
 
 - name: Disable puppet agent (preprod)
   shell: /opt/puppet/bin/puppet agent --disable
   ignore_errors: yes
+  when: puppet_agent_rpm_check.rc == 0

--- a/setup-playbook.yaml
+++ b/setup-playbook.yaml
@@ -1,13 +1,13 @@
 ---
 # Common initialization play (webproxy, certificates, repositories)
 - hosts: all
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   roles:
     - common
 
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   roles:
     - fetch_existing_certificates
 
@@ -17,9 +17,9 @@
 
 # Configure kubernetes Master node
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
-  roles: 
+  roles:
     - etcd
 
   tasks:
@@ -39,7 +39,7 @@
 
   - name: Check if flannel config exists (OK if this fails)
     shell: /usr/bin/etcdctl ls /nais/network/config
-    environment: 
+    environment:
       - ETCDCTL_API: 2
     register: flannelconfig
     ignore_errors: yes
@@ -47,12 +47,12 @@
   - name: Set flannel configuration in etcd
     shell: '/usr/bin/etcdctl mkdir /nais/network && \
            /usr/bin/etcdctl mk /nais/network/config  "{ \"Network\": \"{{ pod_network_cidr }}\", \"SubnetLen\": 23, \"Backend\": { \"Type\": \"vxlan\" }}"'
-    environment: 
+    environment:
       - ETCDCTL_API: 2
     when: flannelconfig.rc != 0
 
 - hosts: all
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
 
@@ -108,8 +108,8 @@
 
   - name: Download kubernetes node binaries
     environment: "{{ proxy_env }}"
-    shell: curl -L --insecure https://dl.k8s.io/v{{ k8s_version }}/kubernetes-node-linux-amd64.tar.gz | \ 
-           tar xzf - -C /tmp kubernetes/node/bin/kubectl kubernetes/node/bin/kube-proxy kubernetes/node/bin/kubelet && \ 
+    shell: curl -L --insecure https://dl.k8s.io/v{{ k8s_version }}/kubernetes-node-linux-amd64.tar.gz | \
+           tar xzf - -C /tmp kubernetes/node/bin/kubectl kubernetes/node/bin/kube-proxy kubernetes/node/bin/kubelet && \
            mv /tmp/kubernetes/node/bin/kube-proxy /usr/bin/kube-proxy-{{ k8s_version }} && \
            mv /tmp/kubernetes/node/bin/kubectl /usr/bin/kubectl-{{ k8s_version }} && \
            mv /tmp/kubernetes/node/bin/kubelet /usr/bin/kubelet-{{ k8s_version }}
@@ -120,7 +120,7 @@
 
   - name: Symlink kubernetes node binaries
     file: src=/usr/bin/{{ item }}-{{ k8s_version }} dest=/usr/bin/{{ item }} state=link force=yes
-    with_items: 
+    with_items:
       - kubectl
       - kube-proxy
       - kubelet
@@ -130,7 +130,7 @@
 
   - name: Make kubernetes node binaries executable
     file: path=/usr/bin/{{ item }}-{{ k8s_version }} mode=0755
-    with_items: 
+    with_items:
       - kubectl
       - kube-proxy
       - kubelet
@@ -142,7 +142,7 @@
 
   - name: Copy kube-proxy kubeconfig
     template: src=templates/kubeconfigs/kube-proxy.conf.j2 dest=/etc/kubernetes/kubeconfigs/kube-proxy.conf
-    notify: 
+    notify:
       - restart_kubeproxy
 
   - name: Enable kube-proxy
@@ -154,6 +154,7 @@
 
   - name: Clean up /etc/hosts after puppet
     shell: /bin/sed -i "s/$(/sbin/ifconfig docker0 | grep inet | awk '{print $2}')/$(/sbin/ifconfig $(ls /sys/class/net/ | grep en) | grep inet | awk '{print $2}')/g" /etc/hosts
+    when: puppet_agent_rpm_check.rc == 0
 
   handlers:
     - name: restart_docker
@@ -178,10 +179,10 @@
 
 # Start control plane
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
-  
+
   - name: Copy kubelet service manifest
     template: src=templates/master-kubelet.service.j2 dest=/etc/systemd/system/kubelet.service
     notify:
@@ -200,12 +201,12 @@
       enabled=yes
 
   - name: Generate cluster-admin kubeconfig
-    shell: rm -f /etc/kubernetes/kubeconfigs/cluster-admin.conf && 
+    shell: rm -f /etc/kubernetes/kubeconfigs/cluster-admin.conf &&
            /usr/bin/kubectl config set-cluster {{ cluster_name }} --server=https://{{ groups['masters'][0] }}:6443 --certificate-authority=/etc/kubernetes/pki/ca.pem --embed-certs=true --kubeconfig=/etc/kubernetes/kubeconfigs/cluster-admin.conf &&
            /usr/bin/kubectl config set-credentials {{ cluster_name }}-cluster-admin --client-certificate=/etc/kubernetes/pki/admin.pem --client-key=/etc/kubernetes/pki/admin-key.pem --embed-certs --kubeconfig=/etc/kubernetes/kubeconfigs/cluster-admin.conf &&
            /usr/bin/kubectl config set-context {{ cluster_name }} --cluster={{ cluster_name }} --user={{ cluster_name }}-cluster-admin --kubeconfig=/etc/kubernetes/kubeconfigs/cluster-admin.conf &&
            /usr/bin/kubectl config use-context {{ cluster_name }} --kubeconfig=/etc/kubernetes/kubeconfigs/cluster-admin.conf
-  
+
   - name: Ensure kubectl config directory exists on master
     file: state=directory path=/root/.kube
 
@@ -223,9 +224,9 @@
       - manifests/kube-controller-manager.yaml
       - kubeconfigs/kube-scheduler.conf
       - kubeconfigs/kube-controller-manager.conf
-    notify: 
+    notify:
       - restart_docker
-  
+
   handlers:
     - name: restart_docker
       systemd:
@@ -241,10 +242,10 @@
 
 # Configure workers
 - hosts: workers
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
-  
+
   - name: Copy certificates
     copy: src=target/pki/{{ item }} dest=/etc/kubernetes/pki/ # to ensure idempotency
     with_items:
@@ -263,12 +264,12 @@
 
   - name: Copy kubelet service manifest
     template: src=templates/worker-kubelet.service.j2 dest=/etc/systemd/system/kubelet.service
-    notify: 
+    notify:
       - restart_kubelet
 
   - name: Copy kubelet kubeconfig
     template: src=templates/kubeconfigs/worker-kubelet.conf.j2 dest=/etc/kubernetes/kubeconfigs/kubelet.conf
-    notify: 
+    notify:
       - restart_kubelet
 
   - name: Enable kubelet
@@ -293,7 +294,7 @@
 
 # Install kubernetes addons
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
 
   tasks:
@@ -321,7 +322,7 @@
       - heapster.yaml
       - nais.yaml
     ignore_errors: no
-  
+
   - name: Download helm binaries
     environment: "{{ proxy_env }}"
     shell: curl -L --insecure https://storage.googleapis.com/kubernetes-helm/helm-v{{ helm_version }}-linux-amd64.tar.gz | \
@@ -329,7 +330,7 @@
            mv /tmp/linux-amd64/helm /usr/bin/helm-{{ helm_version }}
     args:
       creates: /usr/bin/helm-{{ helm_version }}
-   
+
   - name: Symlink helm
     file: src=/usr/bin/helm-{{ helm_version }} dest=/usr/bin/helm state=link
 
@@ -344,12 +345,13 @@
 
 # Configure sensu cluster metrics
 - hosts: all
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
 
   tasks:
   - name: Ensure sensu monitoring script folder exists
     file: state=directory path=/etc/sensu/plugins/metrics/nais
+    when: sensu_rpm_check.rc == 0
 
   - name: Ensure sensu monitoring scripts exist
     copy: src=files/sensu/checks/{{ item }} dest=/etc/sensu/plugins/metrics/nais/{{ item }} mode=0775
@@ -360,6 +362,7 @@
       - interface-metrics.sh
       - nodes-metrics.sh
       - process-metrics.sh
+    when: sensu_rpm_check.rc == 0
     notify:
       - restart_sensu
 
@@ -371,15 +374,17 @@
       state=restarted
 
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
 
   tasks:
   - name: Copy sensu client.json with correct config
     template: src=templates/sensu/master-client.json.j2 dest=/etc/sensu/conf.d/client.json
+    when: sensu_rpm_check.rc == 0
 
   - name: Ensure sensu monitoring config for master node exists
     copy: src=files/sensu/config/nais_master_metrics.json dest=/etc/sensu/conf.d/nais_master_metrics.json
+    when: sensu_rpm_check.rc == 0
     notify:
       - restart_sensu
 
@@ -391,15 +396,17 @@
       state=restarted
 
 - hosts: workers
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
 
   tasks:
   - name: Copy sensu client.json with correct config
     template: src=templates/sensu/worker-client.json.j2 dest=/etc/sensu/conf.d/client.json
+    when: sensu_rpm_check.rc == 0
 
   - name: Ensure sensu monitoring config for worker nodes exist
     copy: src=files/sensu/config/nais_worker_metrics.json dest=/etc/sensu/conf.d/nais_worker_metrics.json
+    when: sensu_rpm_check.rc == 0
     notify:
       - restart_sensu
 
@@ -409,4 +416,3 @@
       daemon_reload=yes
       name=sensu-client
       state=restarted
-

--- a/teardown-playbook.yaml
+++ b/teardown-playbook.yaml
@@ -1,7 +1,7 @@
 ---
 # Remove things created by common initialization play (webproxy, certificates, repositories)
 - hosts: all
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
     - name: Remove kubernetes repository
@@ -42,7 +42,7 @@
       ignore_errors: yes
 
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
     - name: Remove files
@@ -63,7 +63,7 @@
       ignore_errors: yes
 
 - hosts: workers
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
     - name: Remove files
@@ -77,7 +77,7 @@
       file: path=target state=absent
 
 - hosts: all
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
   - name: Stop services

--- a/templates/docker-proxy.conf.j2
+++ b/templates/docker-proxy.conf.j2
@@ -1,2 +1,2 @@
 [Service]
-Environment="HTTP_PROXY=http://webproxy-utvikler.nav.no:8088/" "HTTPS_PROXY=http://webproxy-utvikler.nav.no:8088/" "NO_PROXY=localhost,127.0.0.1,.local,.adeo.no,preprod.local,test.local,.nav.no,.devillo.no,.oera.no,oera-q.local,oera-t.local,{{ ansible_default_ipv4.address }}"
+Environment="HTTP_PROXY={{ proxy_env.http_proxy }}" "HTTPS_PROXY={{ proxy_env.https_proxy }}" "NO_PROXY={{ proxy_env.no_proxy }}"

--- a/test-playbook.yaml
+++ b/test-playbook.yaml
@@ -2,7 +2,7 @@
 
 
 - hosts: masters
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   vars:
     HOST_COUNT: "{{ groups['all'] | length }}"
@@ -42,7 +42,7 @@
       failed_when: matches_spec.stdout != "1"
 
 - hosts: workers
-  user: deployer
+  user: "{{ remote_user }}"
   become: yes
   tasks:
 


### PR DESCRIPTION
I made several changes so naisible can run on hosts outside NAV. I have tested on CentOS 7.3 i Azure.  
  * Changed the proxy settings so there's no proxy by default. To configure a proxy, use nais_http_proxy, nais_https_proxy and nais_no_proxy variables in your inventory file. 
  * Added a variable for remote_user. deployer is still default user.
  * Skipping configuration of sensu, if sensu is not installed.
  * Skipping disabling of puppet-agent if it is not installed.  