### PR TITLE
Set max size on docker logs.

### DIFF
--- a/files/daemon.json
+++ b/files/daemon.json
@@ -1,0 +1,6 @@
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "50m"
+  }
+}

--- a/setup-playbook.yaml
+++ b/setup-playbook.yaml
@@ -85,6 +85,11 @@
     notify:
       - restart_docker
 
+  - name: Setup docker daemon
+    copy: src=files/daemon.json  dest=/etc/docker/daemon.json
+    notify:
+      - restart_docker
+
   - name: Start and enable docker
     systemd:
       daemon_reload=yes


### PR DESCRIPTION
The default log size for a container using the json driver is unlimited. 
As EFK is allready indexing container logs there is no reason to keep the logs on disk indefinitely.

https://docs.docker.com/engine/admin/logging/json-file/