### PR TITLE
removed ip from list of ipsan/hosts

### DIFF
--- a/example-inventory-file
+++ b/example-inventory-file
@@ -8,7 +8,6 @@
 <etcd-node-hostname-n>
 
 [all:vars]
-master_ip=10.181.160.99
 cluster_name=nais-dev
 service_cidr=10.254.0.0/16
 kubernetes_default_ip=10.254.0.1

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,6 @@ Variables
 #### Cluster specific variables
 |Variable name|Value|Information|
 |---|---|---|
-|master_ip|10.181.160.89|Host IP of the master node|
 |cluster_name|nais-dev|The default domain name in the cluster|
 |service_cidr|10.254.0.0/16|CIDR where all k8s services will recide. Addresses in this CIDR will only exist in iptables on the cluster nodes, but should not overlap with existing network CIDRs, as there might be existing services operating in the same range |
 |kubernetes_default_ip|10.254.0.1|Normally the first address in the service CIDR. This address will be allocated for the "kubernetes.default" service|
@@ -151,7 +150,6 @@ worker1.domain.com
 worker2.domain.com
 
 [all:vars]
-master_ip=10.181.160.89
 cluster_name=nais
 service_cidr=10.254.0.0/16
 kubernetes_default_ip=10.254.0.1
@@ -174,7 +172,6 @@ worker1.domain.com
 worker2.domain.com
 
 [all:vars]
-master_ip=10.181.160.89
 cluster_name=nais
 service_cidr=10.254.0.0/16
 kubernetes_default_ip=10.254.0.1

--- a/templates/kube-apiserver-server-csr.j2
+++ b/templates/kube-apiserver-server-csr.j2
@@ -8,8 +8,7 @@
     "kubernetes.default.svc",
     "kubernetes.default.svc.{{ cluster_domain }}",
     "*.{{ domain }}",
-    "{{ hostvars[groups['masters'][0]]['ansible_hostname'] }}",
-    "{{ master_ip }}"
+    "{{ groups['masters'][0] }}"
   ],
   "key": {
     "algo": "rsa",

--- a/templates/kubeconfigs/kube-proxy.conf.j2
+++ b/templates/kubeconfigs/kube-proxy.conf.j2
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - cluster:
     certificate-authority: /etc/kubernetes/pki/ca.pem
-    server: https://{{ master_ip }}:6443
+    server: https://{{ groups['masters'][0] }}:6443
   name: kubernetes
 contexts:
 - context:

--- a/templates/kubeconfigs/worker-kubelet.conf.j2
+++ b/templates/kubeconfigs/worker-kubelet.conf.j2
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - cluster:
     certificate-authority: /etc/kubernetes/pki/ca.pem
-    server: https://{{ master_ip }}:6443
+    server: https://{{ groups['masters'][0] }}:6443
   name: kubernetes
 contexts:
 - context:


### PR DESCRIPTION
to make it easier to switch hosts we should use a name instead of ip
to talk with the apiserver