### PR TITLE
Upgrade Kubernetes to v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Hosts
 <etcd-node-hostname-1>
 <etcd-node-hostname-n>
 ```
+```
+[coreos]
+<coreos-node-hostname-1>
+<coreos-node-hostname-n>
+```
 
 Variables
 ---
@@ -95,7 +100,6 @@ Variables
 |Variable name|Version|Version information location|
 |---|---|---|
 |docker_version|17.03.2.ce|https://download.docker.com/linux/centos/7/x86_64/stable/Packages/|
-|cni_version|0.6.0|https://github.com/containernetworking/cni/releases|
 |etcd_version|3.2.9|https://github.com/coreos/etcd/releases/|
 |flannel_version|0.9.0|https://github.com/coreos/flannel/releases|
 |k8s_version|1.8.1|https://github.com/kubernetes/kubernetes/releases|

--- a/group_vars/all
+++ b/group_vars/all
@@ -8,10 +8,9 @@ remote_user: "{{ nais_remote_user | default('deployer') }}"
 
 # Version specific variables
 docker_version: 17.03.2.ce
-cni_version: 0.6.0
 etcd_version: 3.2.9
 flannel_version: 0.9.0
-k8s_version: 1.9.2
+k8s_version: 1.11.0
 dashboard_version: 1.8.2
 coredns_version: 1.1.1
 traefik_version: 1.6.4-alpine

--- a/templates/manifests/kube-apiserver.yaml.j2
+++ b/templates/manifests/kube-apiserver.yaml.j2
@@ -31,7 +31,6 @@ spec:
     - --kubelet-client-certificate=/etc/kubernetes/pki/admin.pem
     - --kubelet-client-key=/etc/kubernetes/pki/admin-key.pem
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-    - --tls-ca-file=/etc/kubernetes/pki/ca.pem
     - --tls-cert-file=/etc/kubernetes/pki/kube-apiserver-server.pem
     - --tls-private-key-file=/etc/kubernetes/pki/kube-apiserver-server-key.pem
     - --secure-port=6443

--- a/templates/manifests/kube-controller-manager.yaml.j2
+++ b/templates/manifests/kube-controller-manager.yaml.j2
@@ -7,6 +7,7 @@ metadata:
     tier: control-plane
   annotations:
     nais.io/logformat: glog
+    scheduler.alpha.kubernetes.io/critical-pod: ""
   name: kube-controller-manager
   namespace: kube-system
 spec:
@@ -48,6 +49,7 @@ spec:
     - mountPath: /etc/pki
       name: pki
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   volumes:
   - hostPath:
       path: /etc/kubernetes

--- a/templates/manifests/kube-scheduler.yaml.j2
+++ b/templates/manifests/kube-scheduler.yaml.j2
@@ -7,6 +7,7 @@ metadata:
     tier: control-plane
   annotations:
     nais.io/logformat: glog
+    scheduler.alpha.kubernetes.io/critical-pod: ""
   name: kube-scheduler
   namespace: kube-system
 spec:
@@ -36,6 +37,7 @@ spec:
       name: k8s
       readOnly: true
   hostNetwork: true
+  priorityClassName: system-cluster-critical
   volumes:
   - hostPath:
       path: /etc/kubernetes

--- a/templates/master-kubelet.service.j2
+++ b/templates/master-kubelet.service.j2
@@ -4,7 +4,7 @@ Documentation=http://kubernetes.io/docs/
 
 [Service]
 Environment=HOME=/root
-ExecStart={{ install_dir}}/bin/kubelet --hostname-override {{ inventory_hostname }} --node-labels=nais.io/type=master --allow-privileged=true --image-pull-progress-deadline=10m --pod-manifest-path=/etc/kubernetes/manifests --v={{log_level | default(2) }} --register-with-taints=node.alpha.kubernetes.io/ismaster=:NoSchedule --require-kubeconfig --kubeconfig=/etc/kubernetes/kubeconfigs/kubelet.conf --cadvisor-port 0 --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --volume-plugin-dir={{ volume_plugin_dir }}
+ExecStart={{ install_dir}}/bin/kubelet --hostname-override {{ inventory_hostname }} --node-labels=nais.io/type=master --allow-privileged=true --image-pull-progress-deadline=10m --pod-manifest-path=/etc/kubernetes/manifests --v={{log_level | default(2) }} --register-with-taints=node.alpha.kubernetes.io/ismaster=:NoSchedule --kubeconfig=/etc/kubernetes/kubeconfigs/kubelet.conf --cadvisor-port 0 --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --volume-plugin-dir={{ volume_plugin_dir }}
 
 Restart=always
 StartLimitInterval=0

--- a/templates/worker-kubelet.service.j2
+++ b/templates/worker-kubelet.service.j2
@@ -4,7 +4,7 @@ Documentation=http://kubernetes.io/docs/
 
 [Service]
 Environment=HOME=/root
-ExecStart={{ install_dir}}/bin/kubelet --hostname-override {{ inventory_hostname }} --node-labels=nais.io/type=worker --cluster-dns={{ cluster_dns_ip }} --cluster-domain={{ cluster_domain }} --image-pull-progress-deadline=10m --anonymous-auth=false --client-ca-file=/etc/kubernetes/pki/ca.pem --require-kubeconfig --kubeconfig=/etc/kubernetes/kubeconfigs/kubelet.conf --cadvisor-port 0 --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --allow-privileged=true --v={{ log_level | default(0) }} --image-gc-high-threshold 80 --image-gc-low-threshold 40 --volume-plugin-dir={{ volume_plugin_dir }}
+ExecStart={{ install_dir}}/bin/kubelet --hostname-override {{ inventory_hostname }} --node-labels=nais.io/type=worker --cluster-dns={{ cluster_dns_ip }} --cluster-domain={{ cluster_domain }} --image-pull-progress-deadline=10m --anonymous-auth=false --client-ca-file=/etc/kubernetes/pki/ca.pem --kubeconfig=/etc/kubernetes/kubeconfigs/kubelet.conf --cadvisor-port 0 --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --allow-privileged=true --v={{ log_level | default(0) }} --image-gc-high-threshold 80 --image-gc-low-threshold 40 --volume-plugin-dir={{ volume_plugin_dir }}
 Restart=always
 StartLimitInterval=0
 RestartSec=10


### PR DESCRIPTION
This patch provisions nodes with Kubernetes v1.11.0.

Note that Docker image locations have changed locations from `gcr.io` to `k8s.gcr.io`. This change had to be applied also to the web proxy configuration.

The playbook was run on nodes already provisioned with v1.9.x from the Naisible master branch. All the nodes were rebooted afterwards for good measure. All pods seem to be running fine.

```
% kubectl get pod --all-namespaces
NAMESPACE     NAME                                              READY     STATUS    RESTARTS   AGE
default       foo-754f46cf6b-7rqhh                              1/1       Running   0          8m
kube-system   coredns-68db7dd64d-mvjwk                          1/1       Running   2          4d
kube-system   coredns-68db7dd64d-zgts8                          1/1       Running   2          4d
kube-system   heapster-564fdf68f5-zzdv5                         1/1       Running   2          4d
kube-system   kube-apiserver-e34apvl00528.devillo.no            1/1       Running   1          2h
kube-system   kube-controller-manager-e34apvl00528.devillo.no   1/1       Running   1          2h
kube-system   kube-scheduler-e34apvl00528.devillo.no            1/1       Running   1          2h
kube-system   kubernetes-dashboard-58f9cc87fd-4wpm8             1/1       Running   2          4d
kube-system   monitoring-influxdb-7d47b9f8fc-rmqzb              1/1       Running   2          4d
kube-system   tiller-deploy-6fcb585f4f-jwxml                    1/1       Running   2          4d
kube-system   traefik-ingress-controller-k5nvs                  1/1       Running   2          4d
kube-system   traefik-ingress-controller-m7szp                  1/1       Running   2          4d
kube-system   traefik-ingress-controller-ndfpq                  1/1       Running   2          4d
nais          debug-5864b77cbc-wx4f7                            1/1       Running   2          4d
nais          naisd-6766b5b796-m6kcn                            1/1       Running   0          1h
nais          naisd-6766b5b796-w4wc8                            1/1       Running   0          1h
```