### PR TITLE
Enabled clock sync on coreos nodes with systemd-timesyncd

### DIFF
--- a/roles/coreos_bootstrap/handlers/main.yml
+++ b/roles/coreos_bootstrap/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart systemd-timesyncd
+  become: yes
+  service:
+      name: systemd-timesyncd
+      state: restarted

--- a/roles/coreos_bootstrap/tasks/main.yml
+++ b/roles/coreos_bootstrap/tasks/main.yml
@@ -8,3 +8,18 @@
 - name: Run bootstrap.sh
   script: bootstrap.sh
   when: need_bootstrap | failed
+
+- name: Setup timesyncd.conf
+  become: yes
+  template:
+    src: "{{ role_path }}/templates/timesyncd.conf.j2"
+    dest: /etc/systemd/timesyncd.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart systemd-timesyncd
+
+- name: Setup timezone
+  become: yes
+  command: timedatectl set-timezone {{ timezone }}

--- a/roles/coreos_bootstrap/tasks/main.yml
+++ b/roles/coreos_bootstrap/tasks/main.yml
@@ -22,4 +22,5 @@
 
 - name: Setup timezone
   become: yes
-  command: timedatectl set-timezone {{ timezone }}
+  timezone:
+    name: "{{ timezone }}"

--- a/roles/coreos_bootstrap/templates/timesyncd.conf.j2
+++ b/roles/coreos_bootstrap/templates/timesyncd.conf.j2
@@ -1,0 +1,15 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See timesyncd.conf(5) for details.
+
+[Time]
+NTP={{ ntp_servers }}


### PR DESCRIPTION
Testet i nais-dev. Har oppdatert inventory med ntp_servers="<ntp servere for mijøet>" og tidssone.
Det kommer en pull-request i nais-inventory også. Den bør merges først slik at variabler er på plass når denne endringen trår i kraft.