### PR TITLE
Add bigip_pool role

### DIFF
--- a/roles/bigip_pool/tasks/main.yml
+++ b/roles/bigip_pool/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: Add pool member
-  unless: 
   bigip_pool_member:
     server: "{{ bigip_address }}"
     state: present

--- a/roles/bigip_pool/tasks/main.yml
+++ b/roles/bigip_pool/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Add pool member
+  unless: 
+  bigip_pool_member:
+    server: "{{ bigip_address }}"
+    state: present
+    pool: "{{ bigip_pool_name }}"
+    partition: AutoProv
+    host: "{{ ansible_default_ipv4['address'] }}"
+    port: 443
+  delegate_to: localhost
+  when: (
+        bigip_pool_name is defined and
+        bigip_address is defined and
+        )

--- a/setup-playbook.yaml
+++ b/setup-playbook.yaml
@@ -585,3 +585,7 @@
       daemon_reload: yes
       name: sensu-client.service
       state: restarted
+
+- hosts: workers:!storage
+  roles:
+  - bigip_pool


### PR DESCRIPTION
This role adds nodes to a given bigip pool.
Running this role for "workers:!storage" ensures all workers that will
run traefik are present in the given bigip pool.