### PR TITLE
adding pod anti-affinity for coredns

### DIFF
--- a/templates/addons/core-dns.yaml.j2
+++ b/templates/addons/core-dns.yaml.j2
@@ -87,6 +87,13 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9153"
     spec:
+      affinity: # never schedule coredns on a node that is already running one
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:                               
+              matchLabels:                               
+                k8s-app: coredns
       serviceAccountName: coredns
       containers:
       - name: coredns


### PR DESCRIPTION
to avoid potential situation where all replicas of coredns is running on one node during rescheduling, causing potential hickups for the applications