### PR TITLE
bruker ip mot etcd

### DIFF
--- a/templates/flannel.service.j2
+++ b/templates/flannel.service.j2
@@ -1,6 +1,7 @@
 {% set etcd_urls = [] -%}
 {% for host in groups['etcd'] -%}
-  {% set _ = etcd_urls.append("https://%s:2379" % (host)) -%}
+  {% set ip = hostvars[host]['ansible_default_ipv4']['address'] -%}
+  {% set _ = etcd_urls.append("https://%s:2379" % (ip)) -%}
 {% endfor -%}
 [Unit]
 Description=flannel

--- a/templates/manifests/kube-apiserver.yaml.j2
+++ b/templates/manifests/kube-apiserver.yaml.j2
@@ -1,6 +1,7 @@
 {% set etcd_urls = [] -%}
 {% for host in groups['etcd'] -%}
-  {% set _ = etcd_urls.append("https://%s:2379" % (host)) -%}
+  {% set ip = hostvars[host]['ansible_default_ipv4']['address'] -%}
+  {% set _ = etcd_urls.append("https://%s:2379" % (ip)) -%}
 {% endfor -%}
 {% set worker_ips = [] -%}
 {% for host in groups['workers'] -%}

--- a/templates/manifests/kube-apiserver.yaml.j2
+++ b/templates/manifests/kube-apiserver.yaml.j2
@@ -1,7 +1,6 @@
 {% set etcd_urls = [] -%}
 {% for host in groups['etcd'] -%}
-  {% set ip = hostvars[host]['ansible_default_ipv4']['address'] -%}
-  {% set _ = etcd_urls.append("https://%s:2379" % (ip)) -%}
+  {% set _ = etcd_urls.append("https://%s:2379" % (host)) -%}
 {% endfor -%}
 {% set worker_ips = [] -%}
 {% for host in groups['workers'] -%}


### PR DESCRIPTION
Skulle kjapt teste med IP mot etcd, men får et snodig problem med kubectl.

```
$ etcdctl --endpoints https://10.181.160.144:2379,https://10.181.160.182:2379,https://10.181.160.145:2379 cluster-health
member 58a93f6d0b2fcc66 is healthy: got healthy result from https://10.181.160.145:2379
member b7aca988afd18d8d is healthy: got healthy result from https://10.181.160.182:2379
member f834ba2392e823eb is healthy: got healthy result from https://10.181.160.144:2379
cluster is healthy
```

men når jeg kjører
```
$ kubectl get componentstatuses
NAME                 STATUS      MESSAGE                                                                                                                               ERROR
scheduler            Healthy     ok                                                                                                                                    
controller-manager   Healthy     ok                                                                                                                                    
etcd-0               Unhealthy   Get https://10.181.160.182:2379/health: x509: cannot validate certificate for 10.181.160.182 because it doesn't contain any IP SANs   
etcd-2               Unhealthy   Get https://10.181.160.144:2379/health: x509: cannot validate certificate for 10.181.160.144 because it doesn't contain any IP SANs   
etcd-1               Unhealthy   Get https://10.181.160.145:2379/health: x509: cannot validate certificate for 10.181.160.145 because it doesn't contain any IP SANs
```

Noen som har noen tanker?